### PR TITLE
Add all remark fields to parsing switch statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ include $(BOLOS_SDK)/Makefile.defines
 # Main app configuration
 
 APPNAME = "NEO"
-APPVERSION = 1.3.3
+APPVERSION = 1.3.4
 APP_LOAD_PARAMS = --path "44'/888'" --path "44'/1024'" --appFlags 0x40 --apdu $(COMMON_LOAD_PARAMS)
 APP_DELETE_PARAMS =  --apdu $(COMMON_DELETE_PARAMS)
 

--- a/src/neo.c
+++ b/src/neo.c
@@ -591,6 +591,21 @@ unsigned char display_tx_desc() {
 
 		case DESCRIPTION:
 		case REMARK:
+		case REMARK1:
+		case REMARK2:
+		case REMARK3:
+		case REMARK4:
+		case REMARK5:
+		case REMARK6:
+		case REMARK7:
+		case REMARK8:
+		case REMARK9:
+		case REMARK10:
+		case REMARK11:
+		case REMARK12:
+		case REMARK13:
+		case REMARK14:
+		case REMARK15:
 			skip_raw_tx(next_raw_tx_varbytes_num());
 			break;
 


### PR DESCRIPTION
When passing a transaction into the ledger who uses any of the `REMARK` fields beyond the first one, the app will throw an error. This PR adds in the remainder of the `REMARK` fields to the transaction parsing switch statement.